### PR TITLE
Build only last golang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: go
 
 go:
-  - 1.6
   - 1.7
 
 branches:


### PR DESCRIPTION
While the issue https://github.com/travis-ci/travis-ci/issues/929 is not resolved lets build only for the latest golang version.
That's because the `after_success` step must be executed just once after all build matrix.